### PR TITLE
CI: Build ChatGPT Windows .msi (Claude managed)

### DIFF
--- a/.github/actions/pake-windows-build/action.yml
+++ b/.github/actions/pake-windows-build/action.yml
@@ -26,6 +26,10 @@ inputs:
   release-tag:
     description: "GitHub Release tag the .exe is published to."
     required: true
+  icon-url:
+    description: "Optional URL to a PNG icon. When provided, the runner downloads it, converts to .ico (multi-resolution, 16/32/48/64/128/256), and places it at src-tauri/png/<app-name>_256.ico where the build step auto-picks it up. Skipped if empty."
+    required: false
+    default: ""
   github-token:
     description: "Token used to publish the Release. Pass secrets.GITHUB_TOKEN from the calling workflow."
     required: true
@@ -46,6 +50,36 @@ runs:
     - name: Build Pake CLI
       shell: pwsh
       run: pnpm run cli:build
+
+    - name: Fetch and convert app icon
+      if: inputs.icon-url != ''
+      shell: pwsh
+      env:
+        ICON_URL: ${{ inputs.icon-url }}
+        APP_NAME: ${{ inputs.app-name }}
+      run: |
+        $pngPath = "src-tauri\png\${env:APP_NAME}_source.png"
+        $icoPath = "src-tauri\png\${env:APP_NAME}_256.ico"
+
+        Write-Host "Fetching icon: $env:ICON_URL"
+        Invoke-WebRequest -Uri $env:ICON_URL -OutFile $pngPath -UseBasicParsing
+
+        $pngSize = (Get-Item $pngPath).Length
+        if ($pngSize -lt 1024) {
+          Write-Error "Downloaded icon is suspiciously small ($pngSize bytes); aborting."
+          exit 1
+        }
+        Write-Host "Downloaded $([math]::Round($pngSize / 1KB, 2)) KB"
+
+        # ImageMagick ships with windows-latest. Produce a multi-resolution .ico
+        # so Windows can pick the right size for taskbar / explorer / alt-tab.
+        magick $pngPath -define icon:auto-resize=256,128,64,48,32,16 $icoPath
+        if (-not (Test-Path $icoPath)) {
+          Write-Error "ImageMagick did not produce $icoPath"
+          exit 1
+        }
+
+        Write-Host "Generated $icoPath ($([math]::Round((Get-Item $icoPath).Length / 1KB, 2)) KB)"
 
     - name: Build ${{ inputs.app-title }}
       shell: pwsh

--- a/.github/actions/pake-windows-build/action.yml
+++ b/.github/actions/pake-windows-build/action.yml
@@ -27,7 +27,7 @@ inputs:
     description: "GitHub Release tag the .exe is published to."
     required: true
   github-token:
-    description: "Token used to publish the Release. Pass `${{ secrets.GITHUB_TOKEN }}`."
+    description: "Token used to publish the Release. Pass secrets.GITHUB_TOKEN from the calling workflow."
     required: true
 
 runs:

--- a/.github/actions/pake-windows-build/action.yml
+++ b/.github/actions/pake-windows-build/action.yml
@@ -1,0 +1,143 @@
+name: "Pake Windows Portable Build"
+description: "Build a Pake-wrapped web app as a portable Windows .exe and publish it to a GitHub Release."
+
+inputs:
+  app-name:
+    description: "Lowercase app identifier; used for the local icon lookup (src-tauri/png/<name>_256.ico) and matches pake mainBinaryName (pake-<name>.exe)."
+    required: true
+  app-title:
+    description: "Display name. Also used as the published .exe filename (`<title>.exe`)."
+    required: true
+  app-url:
+    description: "URL to package."
+    required: true
+  app-width:
+    description: "Initial window width."
+    required: false
+    default: "1200"
+  app-height:
+    description: "Initial window height."
+    required: false
+    default: "780"
+  extra-flags:
+    description: "Space-separated extra Pake CLI flags, e.g. '--new-window --force-internal-navigation'."
+    required: false
+    default: ""
+  release-tag:
+    description: "GitHub Release tag the .exe is published to."
+    required: true
+  github-token:
+    description: "Token used to publish the Release. Pass `${{ secrets.GITHUB_TOKEN }}`."
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: stable-x86_64-msvc
+
+    - name: Setup Node.js Environment
+      uses: ./.github/actions/setup-env
+      with:
+        mode: build
+
+    - name: Build Pake CLI
+      shell: pwsh
+      run: pnpm run cli:build
+
+    - name: Build ${{ inputs.app-title }}
+      shell: pwsh
+      env:
+        APP_NAME: ${{ inputs.app-name }}
+        APP_TITLE: ${{ inputs.app-title }}
+        APP_URL: ${{ inputs.app-url }}
+        APP_WIDTH: ${{ inputs.app-width }}
+        APP_HEIGHT: ${{ inputs.app-height }}
+        EXTRA_FLAGS: ${{ inputs.extra-flags }}
+      run: |
+        $cliArgs = @(
+          "${env:APP_URL}",
+          "--name", "${env:APP_TITLE}",
+          "--width", "${env:APP_WIDTH}",
+          "--height", "${env:APP_HEIGHT}",
+          "--targets", "x64"
+        )
+
+        if ($env:EXTRA_FLAGS) {
+          foreach ($f in ($env:EXTRA_FLAGS -split '\s+' | Where-Object { $_ })) {
+            $cliArgs += $f
+          }
+        }
+
+        $iconPath = "src-tauri\png\${env:APP_NAME}_256.ico"
+        if (Test-Path $iconPath) {
+          $cliArgs += @("--icon", $iconPath)
+        }
+
+        Write-Host "Running: node dist/cli.js $cliArgs"
+        node dist/cli.js @cliArgs
+
+        New-Item -Path "output\windows" -ItemType Directory -Force | Out-Null
+
+        # Pake sets mainBinaryName = "pake-<lowercased-alnum-name>", so the raw
+        # Tauri binary lives at target/<triple>/release/pake-<name>.exe.
+        $releaseDir = "src-tauri\target\x86_64-pc-windows-msvc\release"
+        $primaryExe = Join-Path $releaseDir "pake-${env:APP_NAME}.exe"
+
+        $exePath = $null
+        if (Test-Path $primaryExe) {
+          $exePath = $primaryExe
+        } else {
+          $candidates = Get-ChildItem -Path $releaseDir -Filter "*.exe" -File -ErrorAction SilentlyContinue
+          $candidates = $candidates | Where-Object {
+            $_.Name -notmatch '^(build-script|.*-[0-9a-f]{16,})\.exe$'
+          }
+          if ($candidates) {
+            $exePath = $candidates[0].FullName
+          }
+        }
+
+        if (-not $exePath) {
+          Write-Error "Could not locate compiled .exe in $releaseDir"
+          Get-ChildItem -Path $releaseDir -Filter "*.exe" -File -ErrorAction SilentlyContinue | ForEach-Object { Write-Host "  $($_.Name)  ($([math]::Round($_.Length / 1MB, 2)) MB)" }
+          exit 1
+        }
+
+        $destination = "output\windows\${env:APP_TITLE}.exe"
+        Copy-Item -Path $exePath -Destination $destination -Force
+        $sizeMB = [math]::Round((Get-Item $destination).Length / 1MB, 2)
+        Write-Host "Portable EXE ready: $destination ($sizeMB MB)"
+
+        git checkout -- src-tauri/Cargo.lock
+
+    - name: Upload build artifact
+      uses: actions/upload-artifact@v6
+      with:
+        name: ${{ inputs.app-title }}-windows-portable
+        path: output/windows/*.exe
+        retention-days: 7
+
+    - name: Publish GitHub Release
+      uses: ncipollo/release-action@v1
+      with:
+        tag: ${{ inputs.release-tag }}
+        name: ${{ inputs.app-title }} (portable, Claude auto-build)
+        body: |
+          Portable Pake build of ${{ inputs.app-title }} for Windows. Drop `${{ inputs.app-title }}.exe` into any folder and run it directly — no installation needed.
+
+          **Setup tip:** put it in your PATH-registered tools folder to launch from terminal.
+
+          **Requires:** Microsoft Edge WebView2 Runtime (preinstalled on Windows 10 21H2+ and Windows 11; if missing, install the evergreen bootstrapper from https://developer.microsoft.com/en-us/microsoft-edge/webview2/).
+
+          ---
+          - Source URL: ${{ inputs.app-url }}
+          - Window size: ${{ inputs.app-width }}x${{ inputs.app-height }}
+          - Extra flags: `${{ inputs.extra-flags }}`
+          - Built from commit ${{ github.sha }}
+          - Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        allowUpdates: true
+        replacesArtifacts: true
+        artifacts: "output/windows/*.exe"
+        token: ${{ inputs.github-token }}

--- a/.github/workflows/claude-chatgpt-build.yaml
+++ b/.github/workflows/claude-chatgpt-build.yaml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: claude-chatgpt-build
+  cancel-in-progress: true
+
 env:
   NODE_VERSION: "22"
   PNPM_VERSION: "10.26.2"
@@ -23,7 +27,7 @@ env:
 
 jobs:
   build-windows:
-    name: Build ChatGPT (Windows)
+    name: Build ChatGPT (Windows portable .exe)
     runs-on: windows-latest
     timeout-minutes: 30
     steps:
@@ -43,7 +47,7 @@ jobs:
       - name: Build Pake CLI
         run: pnpm run cli:build
 
-      - name: Build ChatGPT MSI
+      - name: Build ChatGPT (Tauri produces both .exe and .msi; we keep the .exe)
         shell: pwsh
         run: |
           $cliArgs = @(
@@ -64,66 +68,64 @@ jobs:
 
           New-Item -Path "output\windows" -ItemType Directory -Force | Out-Null
 
-          $candidates = @(
-            "${env:APP_TITLE}.msi",
-            "${env:APP_NAME}.msi"
-          )
+          # Pake sets mainBinaryName = "pake-<lowercased-alnum-name>", so the
+          # raw Tauri binary lives at target/<triple>/release/pake-chatgpt.exe.
+          $releaseDir = "src-tauri\target\x86_64-pc-windows-msvc\release"
+          $primaryExe = Join-Path $releaseDir "pake-chatgpt.exe"
 
-          $found = $null
-          foreach ($candidate in $candidates) {
-            if (Test-Path $candidate) {
-              $found = $candidate
-              break
+          $exePath = $null
+          if (Test-Path $primaryExe) {
+            $exePath = $primaryExe
+          } else {
+            # Fallback: scan release dir (top level only, ignore deps/build subdirs)
+            $candidates = Get-ChildItem -Path $releaseDir -Filter "*.exe" -File -ErrorAction SilentlyContinue
+            $candidates = $candidates | Where-Object {
+              $_.Name -notmatch '^(build-script|.*-[0-9a-f]{16,})\.exe$'
+            }
+            if ($candidates) {
+              $exePath = $candidates[0].FullName
             }
           }
 
-          if (-not $found) {
-            $msiFiles = Get-ChildItem -Path "src-tauri\target\x86_64-pc-windows-msvc\release\bundle\msi\*.msi" -ErrorAction SilentlyContinue
-            if (-not $msiFiles) {
-              $msiFiles = Get-ChildItem -Path "src-tauri\target\release\bundle\msi\*.msi" -ErrorAction SilentlyContinue
-            }
-            if ($msiFiles) {
-              $found = $msiFiles[0].FullName
-            }
-          }
-
-          if (-not $found) {
-            Write-Error "No MSI files produced. Searched:"
-            Write-Host "  - ${env:APP_TITLE}.msi (project root)"
-            Write-Host "  - ${env:APP_NAME}.msi (project root)"
-            Write-Host "  - src-tauri\target\x86_64-pc-windows-msvc\release\bundle\msi\"
-            Write-Host "  - src-tauri\target\release\bundle\msi\"
-            Write-Host "All MSI files under src-tauri\target:"
-            Get-ChildItem -Path "src-tauri\target\" -Recurse -Filter "*.msi" -ErrorAction SilentlyContinue | ForEach-Object { Write-Host $_.FullName }
+          if (-not $exePath) {
+            Write-Error "Could not locate compiled .exe in $releaseDir"
+            Write-Host "Top-level .exe files in release dir:"
+            Get-ChildItem -Path $releaseDir -Filter "*.exe" -File -ErrorAction SilentlyContinue | ForEach-Object { Write-Host "  $($_.Name)  ($([math]::Round($_.Length / 1MB, 2)) MB)" }
             exit 1
           }
 
-          $destination = "output\windows\${env:APP_TITLE}_x64.msi"
-          Move-Item -Path $found -Destination $destination -Force
-          Write-Host "Final MSI: $destination"
+          $destination = "output\windows\${env:APP_TITLE}.exe"
+          Copy-Item -Path $exePath -Destination $destination -Force
+          $sizeMB = [math]::Round((Get-Item $destination).Length / 1MB, 2)
+          Write-Host "Portable EXE ready: $destination ($sizeMB MB)"
 
           git checkout -- src-tauri/Cargo.lock
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v6
         with:
-          name: ChatGPT-windows
-          path: output/windows/*.msi
+          name: ChatGPT-windows-portable
+          path: output/windows/*.exe
           retention-days: 7
 
       - name: Publish GitHub Release
         uses: ncipollo/release-action@v1
         with:
           tag: ${{ env.RELEASE_TAG }}
-          name: ChatGPT (Claude auto-build)
+          name: ChatGPT (portable, Claude auto-build)
           body: |
-            Automated Pake build of ChatGPT for Windows.
+            Portable Pake build of ChatGPT for Windows. Drop `ChatGPT.exe` into any folder and run it directly — no installation needed.
 
+            **Setup tip:** put it in your PATH-registered tools folder to launch from terminal.
+
+            **Requires:** Microsoft Edge WebView2 Runtime (preinstalled on Windows 10 21H2+ and Windows 11; if missing, install the evergreen bootstrapper from https://developer.microsoft.com/en-us/microsoft-edge/webview2/).
+
+            ---
             - Source URL: ${{ env.APP_URL }}
             - Window size: ${{ env.APP_WIDTH }}x${{ env.APP_HEIGHT }}
             - Built from commit ${{ github.sha }}
             - Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           allowUpdates: true
           replacesArtifacts: true
-          artifacts: "output/windows/*.msi"
+          artifacts: "output/windows/*.exe"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-chatgpt-build.yaml
+++ b/.github/workflows/claude-chatgpt-build.yaml
@@ -1,0 +1,129 @@
+name: Build ChatGPT Windows (Claude)
+
+on:
+  push:
+    branches:
+      - claude/pake-exe-builder-evaluation-las7e
+    paths:
+      - ".github/workflows/claude-chatgpt-build.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  NODE_VERSION: "22"
+  PNPM_VERSION: "10.26.2"
+  APP_NAME: chatgpt
+  APP_TITLE: ChatGPT
+  APP_URL: https://chatgpt.com/
+  APP_WIDTH: "1200"
+  APP_HEIGHT: "780"
+  RELEASE_TAG: claude-chatgpt-build
+
+jobs:
+  build-windows:
+    name: Build ChatGPT (Windows)
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable-x86_64-msvc
+
+      - name: Setup Node.js Environment
+        uses: ./.github/actions/setup-env
+        with:
+          mode: build
+
+      - name: Build Pake CLI
+        run: pnpm run cli:build
+
+      - name: Build ChatGPT MSI
+        shell: pwsh
+        run: |
+          $cliArgs = @(
+            "${env:APP_URL}",
+            "--name", "${env:APP_TITLE}",
+            "--width", "${env:APP_WIDTH}",
+            "--height", "${env:APP_HEIGHT}",
+            "--targets", "x64"
+          )
+
+          $iconPath = "src-tauri\png\${env:APP_NAME}_256.ico"
+          if (Test-Path $iconPath) {
+            $cliArgs += @("--icon", $iconPath)
+          }
+
+          Write-Host "Running: node dist/cli.js $cliArgs"
+          node dist/cli.js @cliArgs
+
+          New-Item -Path "output\windows" -ItemType Directory -Force | Out-Null
+
+          $candidates = @(
+            "${env:APP_TITLE}.msi",
+            "${env:APP_NAME}.msi"
+          )
+
+          $found = $null
+          foreach ($candidate in $candidates) {
+            if (Test-Path $candidate) {
+              $found = $candidate
+              break
+            }
+          }
+
+          if (-not $found) {
+            $msiFiles = Get-ChildItem -Path "src-tauri\target\x86_64-pc-windows-msvc\release\bundle\msi\*.msi" -ErrorAction SilentlyContinue
+            if (-not $msiFiles) {
+              $msiFiles = Get-ChildItem -Path "src-tauri\target\release\bundle\msi\*.msi" -ErrorAction SilentlyContinue
+            }
+            if ($msiFiles) {
+              $found = $msiFiles[0].FullName
+            }
+          }
+
+          if (-not $found) {
+            Write-Error "No MSI files produced. Searched:"
+            Write-Host "  - ${env:APP_TITLE}.msi (project root)"
+            Write-Host "  - ${env:APP_NAME}.msi (project root)"
+            Write-Host "  - src-tauri\target\x86_64-pc-windows-msvc\release\bundle\msi\"
+            Write-Host "  - src-tauri\target\release\bundle\msi\"
+            Write-Host "All MSI files under src-tauri\target:"
+            Get-ChildItem -Path "src-tauri\target\" -Recurse -Filter "*.msi" -ErrorAction SilentlyContinue | ForEach-Object { Write-Host $_.FullName }
+            exit 1
+          }
+
+          $destination = "output\windows\${env:APP_TITLE}_x64.msi"
+          Move-Item -Path $found -Destination $destination -Force
+          Write-Host "Final MSI: $destination"
+
+          git checkout -- src-tauri/Cargo.lock
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: ChatGPT-windows
+          path: output/windows/*.msi
+          retention-days: 7
+
+      - name: Publish GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ env.RELEASE_TAG }}
+          name: ChatGPT (Claude auto-build)
+          body: |
+            Automated Pake build of ChatGPT for Windows.
+
+            - Source URL: ${{ env.APP_URL }}
+            - Window size: ${{ env.APP_WIDTH }}x${{ env.APP_HEIGHT }}
+            - Built from commit ${{ github.sha }}
+            - Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          allowUpdates: true
+          replacesArtifacts: true
+          artifacts: "output/windows/*.msi"
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-chatgpt-build.yaml
+++ b/.github/workflows/claude-chatgpt-build.yaml
@@ -1,3 +1,4 @@
+# Thin wrapper. All build logic lives in .github/actions/pake-windows-build/.
 name: Build ChatGPT Windows (Claude)
 
 on:

--- a/.github/workflows/claude-chatgpt-build.yaml
+++ b/.github/workflows/claude-chatgpt-build.yaml
@@ -15,117 +15,19 @@ concurrency:
   group: claude-chatgpt-build
   cancel-in-progress: true
 
-env:
-  NODE_VERSION: "22"
-  PNPM_VERSION: "10.26.2"
-  APP_NAME: chatgpt
-  APP_TITLE: ChatGPT
-  APP_URL: https://chatgpt.com/
-  APP_WIDTH: "1200"
-  APP_HEIGHT: "780"
-  RELEASE_TAG: claude-chatgpt-build
-
 jobs:
-  build-windows:
+  build:
     name: Build ChatGPT (Windows portable .exe)
     runs-on: windows-latest
     timeout-minutes: 30
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/pake-windows-build
         with:
-          toolchain: stable-x86_64-msvc
-
-      - name: Setup Node.js Environment
-        uses: ./.github/actions/setup-env
-        with:
-          mode: build
-
-      - name: Build Pake CLI
-        run: pnpm run cli:build
-
-      - name: Build ChatGPT (Tauri produces both .exe and .msi; we keep the .exe)
-        shell: pwsh
-        run: |
-          $cliArgs = @(
-            "${env:APP_URL}",
-            "--name", "${env:APP_TITLE}",
-            "--width", "${env:APP_WIDTH}",
-            "--height", "${env:APP_HEIGHT}",
-            "--targets", "x64"
-          )
-
-          $iconPath = "src-tauri\png\${env:APP_NAME}_256.ico"
-          if (Test-Path $iconPath) {
-            $cliArgs += @("--icon", $iconPath)
-          }
-
-          Write-Host "Running: node dist/cli.js $cliArgs"
-          node dist/cli.js @cliArgs
-
-          New-Item -Path "output\windows" -ItemType Directory -Force | Out-Null
-
-          # Pake sets mainBinaryName = "pake-<lowercased-alnum-name>", so the
-          # raw Tauri binary lives at target/<triple>/release/pake-chatgpt.exe.
-          $releaseDir = "src-tauri\target\x86_64-pc-windows-msvc\release"
-          $primaryExe = Join-Path $releaseDir "pake-chatgpt.exe"
-
-          $exePath = $null
-          if (Test-Path $primaryExe) {
-            $exePath = $primaryExe
-          } else {
-            # Fallback: scan release dir (top level only, ignore deps/build subdirs)
-            $candidates = Get-ChildItem -Path $releaseDir -Filter "*.exe" -File -ErrorAction SilentlyContinue
-            $candidates = $candidates | Where-Object {
-              $_.Name -notmatch '^(build-script|.*-[0-9a-f]{16,})\.exe$'
-            }
-            if ($candidates) {
-              $exePath = $candidates[0].FullName
-            }
-          }
-
-          if (-not $exePath) {
-            Write-Error "Could not locate compiled .exe in $releaseDir"
-            Write-Host "Top-level .exe files in release dir:"
-            Get-ChildItem -Path $releaseDir -Filter "*.exe" -File -ErrorAction SilentlyContinue | ForEach-Object { Write-Host "  $($_.Name)  ($([math]::Round($_.Length / 1MB, 2)) MB)" }
-            exit 1
-          }
-
-          $destination = "output\windows\${env:APP_TITLE}.exe"
-          Copy-Item -Path $exePath -Destination $destination -Force
-          $sizeMB = [math]::Round((Get-Item $destination).Length / 1MB, 2)
-          Write-Host "Portable EXE ready: $destination ($sizeMB MB)"
-
-          git checkout -- src-tauri/Cargo.lock
-
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: ChatGPT-windows-portable
-          path: output/windows/*.exe
-          retention-days: 7
-
-      - name: Publish GitHub Release
-        uses: ncipollo/release-action@v1
-        with:
-          tag: ${{ env.RELEASE_TAG }}
-          name: ChatGPT (portable, Claude auto-build)
-          body: |
-            Portable Pake build of ChatGPT for Windows. Drop `ChatGPT.exe` into any folder and run it directly — no installation needed.
-
-            **Setup tip:** put it in your PATH-registered tools folder to launch from terminal.
-
-            **Requires:** Microsoft Edge WebView2 Runtime (preinstalled on Windows 10 21H2+ and Windows 11; if missing, install the evergreen bootstrapper from https://developer.microsoft.com/en-us/microsoft-edge/webview2/).
-
-            ---
-            - Source URL: ${{ env.APP_URL }}
-            - Window size: ${{ env.APP_WIDTH }}x${{ env.APP_HEIGHT }}
-            - Built from commit ${{ github.sha }}
-            - Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          allowUpdates: true
-          replacesArtifacts: true
-          artifacts: "output/windows/*.exe"
-          token: ${{ secrets.GITHUB_TOKEN }}
+          app-name: chatgpt
+          app-title: ChatGPT
+          app-url: https://chatgpt.com/
+          app-width: "1200"
+          app-height: "780"
+          release-tag: claude-chatgpt-build
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-chatgpt-build.yaml
+++ b/.github/workflows/claude-chatgpt-build.yaml
@@ -7,6 +7,8 @@ on:
       - claude/pake-exe-builder-evaluation-las7e
     paths:
       - ".github/workflows/claude-chatgpt-build.yaml"
+      - "src-tauri/src/**"
+      - "src-tauri/Cargo.toml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/claude-colab-build.yaml
+++ b/.github/workflows/claude-colab-build.yaml
@@ -1,3 +1,4 @@
+# Thin wrapper. All build logic lives in .github/actions/pake-windows-build/.
 name: Build Colab Windows (Claude)
 
 on:

--- a/.github/workflows/claude-colab-build.yaml
+++ b/.github/workflows/claude-colab-build.yaml
@@ -7,6 +7,8 @@ on:
       - claude/pake-exe-builder-evaluation-las7e
     paths:
       - ".github/workflows/claude-colab-build.yaml"
+      - "src-tauri/src/**"
+      - "src-tauri/Cargo.toml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/claude-colab-build.yaml
+++ b/.github/workflows/claude-colab-build.yaml
@@ -15,122 +15,20 @@ concurrency:
   group: claude-colab-build
   cancel-in-progress: true
 
-env:
-  NODE_VERSION: "22"
-  PNPM_VERSION: "10.26.2"
-  APP_NAME: colab
-  APP_TITLE: Colab
-  APP_URL: https://colab.research.google.com/
-  APP_WIDTH: "1280"
-  APP_HEIGHT: "820"
-  RELEASE_TAG: claude-colab-build
-
 jobs:
-  build-windows:
+  build:
     name: Build Colab (Windows portable .exe)
     runs-on: windows-latest
     timeout-minutes: 30
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/pake-windows-build
         with:
-          toolchain: stable-x86_64-msvc
-
-      - name: Setup Node.js Environment
-        uses: ./.github/actions/setup-env
-        with:
-          mode: build
-
-      - name: Build Pake CLI
-        run: pnpm run cli:build
-
-      - name: Build Colab (force every nav to stay in-app)
-        shell: pwsh
-        run: |
-          # --force-internal-navigation: never hand off to system browser
-          # --new-window: window.open() / popups stay as Pake child windows
-          $cliArgs = @(
-            "${env:APP_URL}",
-            "--name", "${env:APP_TITLE}",
-            "--width", "${env:APP_WIDTH}",
-            "--height", "${env:APP_HEIGHT}",
-            "--targets", "x64",
-            "--force-internal-navigation",
-            "--new-window"
-          )
-
-          $iconPath = "src-tauri\png\${env:APP_NAME}_256.ico"
-          if (Test-Path $iconPath) {
-            $cliArgs += @("--icon", $iconPath)
-          }
-
-          Write-Host "Running: node dist/cli.js $cliArgs"
-          node dist/cli.js @cliArgs
-
-          New-Item -Path "output\windows" -ItemType Directory -Force | Out-Null
-
-          # Pake sets mainBinaryName = "pake-<lowercased-alnum-name>", so the
-          # raw Tauri binary lives at target/<triple>/release/pake-colab.exe.
-          $releaseDir = "src-tauri\target\x86_64-pc-windows-msvc\release"
-          $primaryExe = Join-Path $releaseDir "pake-colab.exe"
-
-          $exePath = $null
-          if (Test-Path $primaryExe) {
-            $exePath = $primaryExe
-          } else {
-            $candidates = Get-ChildItem -Path $releaseDir -Filter "*.exe" -File -ErrorAction SilentlyContinue
-            $candidates = $candidates | Where-Object {
-              $_.Name -notmatch '^(build-script|.*-[0-9a-f]{16,})\.exe$'
-            }
-            if ($candidates) {
-              $exePath = $candidates[0].FullName
-            }
-          }
-
-          if (-not $exePath) {
-            Write-Error "Could not locate compiled .exe in $releaseDir"
-            Get-ChildItem -Path $releaseDir -Filter "*.exe" -File -ErrorAction SilentlyContinue | ForEach-Object { Write-Host "  $($_.Name)  ($([math]::Round($_.Length / 1MB, 2)) MB)" }
-            exit 1
-          }
-
-          $destination = "output\windows\${env:APP_TITLE}.exe"
-          Copy-Item -Path $exePath -Destination $destination -Force
-          $sizeMB = [math]::Round((Get-Item $destination).Length / 1MB, 2)
-          Write-Host "Portable EXE ready: $destination ($sizeMB MB)"
-
-          git checkout -- src-tauri/Cargo.lock
-
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: Colab-windows-portable
-          path: output/windows/*.exe
-          retention-days: 7
-
-      - name: Publish GitHub Release
-        uses: ncipollo/release-action@v1
-        with:
-          tag: ${{ env.RELEASE_TAG }}
-          name: Colab (portable, Claude auto-build)
-          body: |
-            Portable Pake build of Google Colab for Windows. Drop `Colab.exe` into any folder and run it directly — no installation needed.
-
-            **All navigation is locked inside the app:** external links and `window.open()` popups will not jump to your system browser, they open as Pake child windows or in-place.
-
-            **Setup tip:** put it in your PATH-registered tools folder to launch from terminal.
-
-            **Requires:** Microsoft Edge WebView2 Runtime (preinstalled on Windows 10 21H2+ and Windows 11; if missing, install the evergreen bootstrapper from https://developer.microsoft.com/en-us/microsoft-edge/webview2/).
-
-            ---
-            - Source URL: ${{ env.APP_URL }}
-            - Window size: ${{ env.APP_WIDTH }}x${{ env.APP_HEIGHT }}
-            - Flags: `--force-internal-navigation --new-window`
-            - Built from commit ${{ github.sha }}
-            - Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          allowUpdates: true
-          replacesArtifacts: true
-          artifacts: "output/windows/*.exe"
-          token: ${{ secrets.GITHUB_TOKEN }}
+          app-name: colab
+          app-title: Colab
+          app-url: https://colab.research.google.com/
+          app-width: "1280"
+          app-height: "820"
+          extra-flags: "--force-internal-navigation --new-window"
+          release-tag: claude-colab-build
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-colab-build.yaml
+++ b/.github/workflows/claude-colab-build.yaml
@@ -33,5 +33,6 @@ jobs:
           app-width: "1280"
           app-height: "820"
           extra-flags: "--force-internal-navigation --new-window"
+          icon-url: "https://colab.research.google.com/img/colab_favicon_256px.png"
           release-tag: claude-colab-build
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-colab-build.yaml
+++ b/.github/workflows/claude-colab-build.yaml
@@ -1,0 +1,136 @@
+name: Build Colab Windows (Claude)
+
+on:
+  push:
+    branches:
+      - claude/pake-exe-builder-evaluation-las7e
+    paths:
+      - ".github/workflows/claude-colab-build.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: claude-colab-build
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: "22"
+  PNPM_VERSION: "10.26.2"
+  APP_NAME: colab
+  APP_TITLE: Colab
+  APP_URL: https://colab.research.google.com/
+  APP_WIDTH: "1280"
+  APP_HEIGHT: "820"
+  RELEASE_TAG: claude-colab-build
+
+jobs:
+  build-windows:
+    name: Build Colab (Windows portable .exe)
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable-x86_64-msvc
+
+      - name: Setup Node.js Environment
+        uses: ./.github/actions/setup-env
+        with:
+          mode: build
+
+      - name: Build Pake CLI
+        run: pnpm run cli:build
+
+      - name: Build Colab (force every nav to stay in-app)
+        shell: pwsh
+        run: |
+          # --force-internal-navigation: never hand off to system browser
+          # --new-window: window.open() / popups stay as Pake child windows
+          $cliArgs = @(
+            "${env:APP_URL}",
+            "--name", "${env:APP_TITLE}",
+            "--width", "${env:APP_WIDTH}",
+            "--height", "${env:APP_HEIGHT}",
+            "--targets", "x64",
+            "--force-internal-navigation",
+            "--new-window"
+          )
+
+          $iconPath = "src-tauri\png\${env:APP_NAME}_256.ico"
+          if (Test-Path $iconPath) {
+            $cliArgs += @("--icon", $iconPath)
+          }
+
+          Write-Host "Running: node dist/cli.js $cliArgs"
+          node dist/cli.js @cliArgs
+
+          New-Item -Path "output\windows" -ItemType Directory -Force | Out-Null
+
+          # Pake sets mainBinaryName = "pake-<lowercased-alnum-name>", so the
+          # raw Tauri binary lives at target/<triple>/release/pake-colab.exe.
+          $releaseDir = "src-tauri\target\x86_64-pc-windows-msvc\release"
+          $primaryExe = Join-Path $releaseDir "pake-colab.exe"
+
+          $exePath = $null
+          if (Test-Path $primaryExe) {
+            $exePath = $primaryExe
+          } else {
+            $candidates = Get-ChildItem -Path $releaseDir -Filter "*.exe" -File -ErrorAction SilentlyContinue
+            $candidates = $candidates | Where-Object {
+              $_.Name -notmatch '^(build-script|.*-[0-9a-f]{16,})\.exe$'
+            }
+            if ($candidates) {
+              $exePath = $candidates[0].FullName
+            }
+          }
+
+          if (-not $exePath) {
+            Write-Error "Could not locate compiled .exe in $releaseDir"
+            Get-ChildItem -Path $releaseDir -Filter "*.exe" -File -ErrorAction SilentlyContinue | ForEach-Object { Write-Host "  $($_.Name)  ($([math]::Round($_.Length / 1MB, 2)) MB)" }
+            exit 1
+          }
+
+          $destination = "output\windows\${env:APP_TITLE}.exe"
+          Copy-Item -Path $exePath -Destination $destination -Force
+          $sizeMB = [math]::Round((Get-Item $destination).Length / 1MB, 2)
+          Write-Host "Portable EXE ready: $destination ($sizeMB MB)"
+
+          git checkout -- src-tauri/Cargo.lock
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: Colab-windows-portable
+          path: output/windows/*.exe
+          retention-days: 7
+
+      - name: Publish GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ env.RELEASE_TAG }}
+          name: Colab (portable, Claude auto-build)
+          body: |
+            Portable Pake build of Google Colab for Windows. Drop `Colab.exe` into any folder and run it directly — no installation needed.
+
+            **All navigation is locked inside the app:** external links and `window.open()` popups will not jump to your system browser, they open as Pake child windows or in-place.
+
+            **Setup tip:** put it in your PATH-registered tools folder to launch from terminal.
+
+            **Requires:** Microsoft Edge WebView2 Runtime (preinstalled on Windows 10 21H2+ and Windows 11; if missing, install the evergreen bootstrapper from https://developer.microsoft.com/en-us/microsoft-edge/webview2/).
+
+            ---
+            - Source URL: ${{ env.APP_URL }}
+            - Window size: ${{ env.APP_WIDTH }}x${{ env.APP_HEIGHT }}
+            - Flags: `--force-internal-navigation --new-window`
+            - Built from commit ${{ github.sha }}
+            - Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          allowUpdates: true
+          replacesArtifacts: true
+          artifacts: "output/windows/*.exe"
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-kook-build.yaml
+++ b/.github/workflows/claude-kook-build.yaml
@@ -15,123 +15,20 @@ concurrency:
   group: claude-kook-build
   cancel-in-progress: true
 
-env:
-  NODE_VERSION: "22"
-  PNPM_VERSION: "10.26.2"
-  APP_NAME: kook
-  APP_TITLE: KOOK
-  # Land directly on /app/channels/ so the user doesn't have to click through
-  # the marketing page on every cold start.
-  APP_URL: https://www.kookapp.cn/app/channels/
-  APP_WIDTH: "1280"
-  APP_HEIGHT: "820"
-  RELEASE_TAG: claude-kook-build
-
 jobs:
-  build-windows:
+  build:
     name: Build KOOK (Windows portable .exe)
     runs-on: windows-latest
     timeout-minutes: 30
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/pake-windows-build
         with:
-          toolchain: stable-x86_64-msvc
-
-      - name: Setup Node.js Environment
-        uses: ./.github/actions/setup-env
-        with:
-          mode: build
-
-      - name: Build Pake CLI
-        run: pnpm run cli:build
-
-      - name: Build KOOK
-        shell: pwsh
-        run: |
-          # --new-window keeps OAuth / popup login flows inside the app,
-          # but external links shared in chat still open in the system browser.
-          $cliArgs = @(
-            "${env:APP_URL}",
-            "--name", "${env:APP_TITLE}",
-            "--width", "${env:APP_WIDTH}",
-            "--height", "${env:APP_HEIGHT}",
-            "--targets", "x64",
-            "--new-window"
-          )
-
-          $iconPath = "src-tauri\png\${env:APP_NAME}_256.ico"
-          if (Test-Path $iconPath) {
-            $cliArgs += @("--icon", $iconPath)
-          }
-
-          Write-Host "Running: node dist/cli.js $cliArgs"
-          node dist/cli.js @cliArgs
-
-          New-Item -Path "output\windows" -ItemType Directory -Force | Out-Null
-
-          # Pake sets mainBinaryName = "pake-<lowercased-alnum-name>", so the
-          # raw Tauri binary lives at target/<triple>/release/pake-kook.exe.
-          $releaseDir = "src-tauri\target\x86_64-pc-windows-msvc\release"
-          $primaryExe = Join-Path $releaseDir "pake-kook.exe"
-
-          $exePath = $null
-          if (Test-Path $primaryExe) {
-            $exePath = $primaryExe
-          } else {
-            $candidates = Get-ChildItem -Path $releaseDir -Filter "*.exe" -File -ErrorAction SilentlyContinue
-            $candidates = $candidates | Where-Object {
-              $_.Name -notmatch '^(build-script|.*-[0-9a-f]{16,})\.exe$'
-            }
-            if ($candidates) {
-              $exePath = $candidates[0].FullName
-            }
-          }
-
-          if (-not $exePath) {
-            Write-Error "Could not locate compiled .exe in $releaseDir"
-            Get-ChildItem -Path $releaseDir -Filter "*.exe" -File -ErrorAction SilentlyContinue | ForEach-Object { Write-Host "  $($_.Name)  ($([math]::Round($_.Length / 1MB, 2)) MB)" }
-            exit 1
-          }
-
-          $destination = "output\windows\${env:APP_TITLE}.exe"
-          Copy-Item -Path $exePath -Destination $destination -Force
-          $sizeMB = [math]::Round((Get-Item $destination).Length / 1MB, 2)
-          Write-Host "Portable EXE ready: $destination ($sizeMB MB)"
-
-          git checkout -- src-tauri/Cargo.lock
-
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: KOOK-windows-portable
-          path: output/windows/*.exe
-          retention-days: 7
-
-      - name: Publish GitHub Release
-        uses: ncipollo/release-action@v1
-        with:
-          tag: ${{ env.RELEASE_TAG }}
-          name: KOOK (portable, Claude auto-build)
-          body: |
-            Portable Pake build of KOOK for Windows. Drop `KOOK.exe` into any folder and run it directly — no installation needed.
-
-            Launches straight into `/app/channels/` so you skip the marketing landing page.
-
-            **Setup tip:** put it in your PATH-registered tools folder to launch from terminal.
-
-            **Requires:** Microsoft Edge WebView2 Runtime (preinstalled on Windows 10 21H2+ and Windows 11; if missing, install the evergreen bootstrapper from https://developer.microsoft.com/en-us/microsoft-edge/webview2/).
-
-            ---
-            - Source URL: ${{ env.APP_URL }}
-            - Window size: ${{ env.APP_WIDTH }}x${{ env.APP_HEIGHT }}
-            - Flags: `--new-window` (login popups in-app; chat-shared external links still open in system browser)
-            - Built from commit ${{ github.sha }}
-            - Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          allowUpdates: true
-          replacesArtifacts: true
-          artifacts: "output/windows/*.exe"
-          token: ${{ secrets.GITHUB_TOKEN }}
+          app-name: kook
+          app-title: KOOK
+          app-url: https://www.kookapp.cn/app/channels/
+          app-width: "1280"
+          app-height: "820"
+          extra-flags: "--new-window"
+          release-tag: claude-kook-build
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-kook-build.yaml
+++ b/.github/workflows/claude-kook-build.yaml
@@ -7,6 +7,8 @@ on:
       - claude/pake-exe-builder-evaluation-las7e
     paths:
       - ".github/workflows/claude-kook-build.yaml"
+      - "src-tauri/src/**"
+      - "src-tauri/Cargo.toml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/claude-kook-build.yaml
+++ b/.github/workflows/claude-kook-build.yaml
@@ -1,0 +1,137 @@
+name: Build KOOK Windows (Claude)
+
+on:
+  push:
+    branches:
+      - claude/pake-exe-builder-evaluation-las7e
+    paths:
+      - ".github/workflows/claude-kook-build.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: claude-kook-build
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: "22"
+  PNPM_VERSION: "10.26.2"
+  APP_NAME: kook
+  APP_TITLE: KOOK
+  # Land directly on /app/channels/ so the user doesn't have to click through
+  # the marketing page on every cold start.
+  APP_URL: https://www.kookapp.cn/app/channels/
+  APP_WIDTH: "1280"
+  APP_HEIGHT: "820"
+  RELEASE_TAG: claude-kook-build
+
+jobs:
+  build-windows:
+    name: Build KOOK (Windows portable .exe)
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable-x86_64-msvc
+
+      - name: Setup Node.js Environment
+        uses: ./.github/actions/setup-env
+        with:
+          mode: build
+
+      - name: Build Pake CLI
+        run: pnpm run cli:build
+
+      - name: Build KOOK
+        shell: pwsh
+        run: |
+          # --new-window keeps OAuth / popup login flows inside the app,
+          # but external links shared in chat still open in the system browser.
+          $cliArgs = @(
+            "${env:APP_URL}",
+            "--name", "${env:APP_TITLE}",
+            "--width", "${env:APP_WIDTH}",
+            "--height", "${env:APP_HEIGHT}",
+            "--targets", "x64",
+            "--new-window"
+          )
+
+          $iconPath = "src-tauri\png\${env:APP_NAME}_256.ico"
+          if (Test-Path $iconPath) {
+            $cliArgs += @("--icon", $iconPath)
+          }
+
+          Write-Host "Running: node dist/cli.js $cliArgs"
+          node dist/cli.js @cliArgs
+
+          New-Item -Path "output\windows" -ItemType Directory -Force | Out-Null
+
+          # Pake sets mainBinaryName = "pake-<lowercased-alnum-name>", so the
+          # raw Tauri binary lives at target/<triple>/release/pake-kook.exe.
+          $releaseDir = "src-tauri\target\x86_64-pc-windows-msvc\release"
+          $primaryExe = Join-Path $releaseDir "pake-kook.exe"
+
+          $exePath = $null
+          if (Test-Path $primaryExe) {
+            $exePath = $primaryExe
+          } else {
+            $candidates = Get-ChildItem -Path $releaseDir -Filter "*.exe" -File -ErrorAction SilentlyContinue
+            $candidates = $candidates | Where-Object {
+              $_.Name -notmatch '^(build-script|.*-[0-9a-f]{16,})\.exe$'
+            }
+            if ($candidates) {
+              $exePath = $candidates[0].FullName
+            }
+          }
+
+          if (-not $exePath) {
+            Write-Error "Could not locate compiled .exe in $releaseDir"
+            Get-ChildItem -Path $releaseDir -Filter "*.exe" -File -ErrorAction SilentlyContinue | ForEach-Object { Write-Host "  $($_.Name)  ($([math]::Round($_.Length / 1MB, 2)) MB)" }
+            exit 1
+          }
+
+          $destination = "output\windows\${env:APP_TITLE}.exe"
+          Copy-Item -Path $exePath -Destination $destination -Force
+          $sizeMB = [math]::Round((Get-Item $destination).Length / 1MB, 2)
+          Write-Host "Portable EXE ready: $destination ($sizeMB MB)"
+
+          git checkout -- src-tauri/Cargo.lock
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: KOOK-windows-portable
+          path: output/windows/*.exe
+          retention-days: 7
+
+      - name: Publish GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ env.RELEASE_TAG }}
+          name: KOOK (portable, Claude auto-build)
+          body: |
+            Portable Pake build of KOOK for Windows. Drop `KOOK.exe` into any folder and run it directly — no installation needed.
+
+            Launches straight into `/app/channels/` so you skip the marketing landing page.
+
+            **Setup tip:** put it in your PATH-registered tools folder to launch from terminal.
+
+            **Requires:** Microsoft Edge WebView2 Runtime (preinstalled on Windows 10 21H2+ and Windows 11; if missing, install the evergreen bootstrapper from https://developer.microsoft.com/en-us/microsoft-edge/webview2/).
+
+            ---
+            - Source URL: ${{ env.APP_URL }}
+            - Window size: ${{ env.APP_WIDTH }}x${{ env.APP_HEIGHT }}
+            - Flags: `--new-window` (login popups in-app; chat-shared external links still open in system browser)
+            - Built from commit ${{ github.sha }}
+            - Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          allowUpdates: true
+          replacesArtifacts: true
+          artifacts: "output/windows/*.exe"
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-kook-build.yaml
+++ b/.github/workflows/claude-kook-build.yaml
@@ -1,3 +1,4 @@
+# Thin wrapper. All build logic lives in .github/actions/pake-windows-build/.
 name: Build KOOK Windows (Claude)
 
 on:

--- a/src-tauri/src/app/window.rs
+++ b/src-tauri/src/app/window.rs
@@ -29,6 +29,36 @@ fn build_proxy_browser_arg(url: &Url) -> Option<String> {
     }
 }
 
+/// Allow the .exe to be launched with a URL argument (e.g.
+/// `Colab.exe "https://colab.research.google.com/notebooks/empty.ipynb#mcpProxyToken=abc&mcpProxyPort=12345"`)
+/// and open that URL instead of the build-time-configured one. The full URL
+/// including its fragment is preserved by `url::Url` parsing, which is what
+/// integrations such as Colab MCP rely on.
+///
+/// Only same-origin overrides are accepted (scheme + host + port must match
+/// the configured URL). Different-origin args are silently ignored so a
+/// shortcut or another process can't trick the app into loading an arbitrary
+/// site.
+fn override_url_from_cli(configured_url: &str) -> Option<String> {
+    let configured = Url::parse(configured_url).ok()?;
+    for arg in std::env::args().skip(1) {
+        if !arg.starts_with("http://") && !arg.starts_with("https://") {
+            continue;
+        }
+        let candidate = match Url::parse(&arg) {
+            Ok(u) => u,
+            Err(_) => continue,
+        };
+        if candidate.scheme() == configured.scheme()
+            && candidate.host_str() == configured.host_str()
+            && candidate.port_or_known_default() == configured.port_or_known_default()
+        {
+            return Some(arg);
+        }
+    }
+    None
+}
+
 pub struct MultiWindowState {
     pub pake_config: PakeConfig,
     pub tauri_config: Config,
@@ -134,13 +164,12 @@ fn build_window_with_label(
     })?;
     let url = match window_config.url_type.as_str() {
         "web" => {
-            let parsed = window_config.url.parse().map_err(|err| {
+            let effective_url = override_url_from_cli(&window_config.url)
+                .unwrap_or_else(|| window_config.url.clone());
+            let parsed = effective_url.parse().map_err(|err| {
                 tauri::Error::Io(std::io::Error::new(
                     std::io::ErrorKind::InvalidInput,
-                    format!(
-                        "Invalid 'web' url '{}' in pake.json: {err}",
-                        window_config.url
-                    ),
+                    format!("Invalid 'web' url '{effective_url}' in pake.json: {err}"),
                 ))
             })?;
             WebviewUrl::App(parsed)


### PR DESCRIPTION
**Do not merge.** This PR exists only as a monitoring channel so Claude Code can subscribe to CI events for the Windows ChatGPT build workflow.

### What this branch adds
- `.github/workflows/claude-chatgpt-build.yaml`: builds Pake CLI on `windows-latest`, packages https://chatgpt.com/ as `ChatGPT_x64.msi`, uploads as artifact, and publishes/updates GitHub Release `claude-chatgpt-build` with the `.msi` attached.

### Where the artifact lands
After a green run, the `.msi` will appear at:
https://github.com/exusiaiwei/pake/releases/tag/claude-chatgpt-build

### Trigger
- Auto on push to this branch (when the workflow file itself changes)
- Manual via Actions → "Build ChatGPT Windows (Claude)" → Run workflow

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ky3nooaPxs26CmmwQTRMfE)_